### PR TITLE
Lock rack to 3.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ gem "rack-cors"
 gem "jsonapi-resources"
 gem "bcrypt"
 gem "doorkeeper"
+gem "rack", "~> 3.0.11"
 
 # for web hooks
 gem "httparty"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -328,6 +328,7 @@ DEPENDENCIES
   jsonapi-resources
   pg (~> 1.5)
   puma
+  rack (~> 3.0.11)
   rack-attack
   rack-cors
   rails (~> 7.1.3)


### PR DESCRIPTION
In 3.1 tests that check status 422 return status 0 instead. Seems due to https://github.com/rack/rack/pull/2137

I assume a non-0 HTTP status is really returned, so presumably some other library updating will fix it at some point.